### PR TITLE
Avoid reading spurious CntR data

### DIFF
--- a/co2mond/src/main.c
+++ b/co2mond/src/main.c
@@ -188,6 +188,10 @@ device_loop(co2mon_device dev)
 
             break;
         case CODE_CNTR:
+            if ((unsigned)w > 3000) {
+                // Avoid reading spurious (uninitialized?) data
+                break;
+            }
             snprintf(buf, VALUE_MAX, "%d", (int)w);
 
             if (!daemonize)


### PR DESCRIPTION
that sometimes appears just after connecting the device