### PR TITLE
Add Fedora and RHEL/CentOS installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 
 `yaourt -S co2mon-git`
 
+### Fedora GNU/Linux and RHEL/CentOS/Scientific Linux
+co2mon packages can be installed from russianfedora-free repo or directly from [koji](http://koji.russianfedora.pro/koji/packageinfo?packageID=174)
+
+Install repo:
+
+`su -c 'dnf install --nogpgcheck http://mirror.yandex.ru/fedora/russianfedora/russianfedora/free/fedora/russianfedora-free-release-stable.noarch.rpm http://mirror.yandex.ru/fedora/russianfedora/russianfedora/nonfree/fedora/russianfedora-nonfree-release-stable.noarch.rpm'`
+
+Install co2mon:
+
+`dnf install co2mon`
+
 ## See also
 
   * [ZyAura ZG01C Module Manual](http://www.zyaura.com/support/manual/pdf/ZyAura_CO2_Monitor_ZG01C_Module_ApplicationNote_141120.pdf)


### PR DESCRIPTION
I build rpm package for Fedora and RHEL/CentOS. Now it in russianfedora repo. In future it can be placed in main Fedora repo.