### PR TITLE
Send heartbeat timestamp to munin

### DIFF
--- a/graph/munin/co2mon
+++ b/graph/munin/co2mon
@@ -38,15 +38,11 @@ print_values() {
     read co2 < "$CO2_FILE"
     read temp < "$TEMP_FILE"
     read heartbeat_sec < "$HEARTBEAT_FILE"
-    if [ $(($(date +%s)-heartbeat_sec)) -gt 60 ]; then
-        co2='U'
-        temp='U'
-    fi
 
     echo 'multigraph co2mon'
-    echo "co2.value ${co2:-U}"
+    echo "co2.value ${heartbeat_sec:+$heartbeat_sec:}${co2:-U}"
     echo 'multigraph co2mon_temp'
-    echo "temp.value ${temp:-U}"
+    echo "temp.value ${heartbeat_sec:+$heartbeat_sec:}${temp:-U}"
 }
 
 if [ "$1" = "autoconf" ]; then


### PR DESCRIPTION
Don't figure out if readings are outdated by ourselves but let munin
decide. Plugin code became a bit shorter and one fork saved.

Munin supports values with timestamps since 1.3.4
http://munin-monitoring.org/wiki/PluginConcise#fetchmandatory

This change does not impose extra requirements for munin on target system
as we already depend on multigraph support which appeared in munin 1.4.0