### PR TITLE
Collectd plugin

### DIFF
--- a/graph/collectd/co2mon.conf.example
+++ b/graph/collectd/co2mon.conf.example
@@ -1,0 +1,14 @@
+# Don't forget to 'LoadPlugin python' or 'AutoLoadPlugin true'
+
+<Plugin python>
+	ModulePath "/etc/collectd_python_plugins"
+	LogTraces true
+	Interactive false
+	Import "co2mon"
+
+	#<Module co2mon>
+	#	#This is default value
+	#	datadir "/var/lib/co2mon/"
+	#</Module>
+</Plugin>
+

--- a/graph/collectd/co2mon.py
+++ b/graph/collectd/co2mon.py
@@ -1,0 +1,36 @@
+import collectd
+import os
+
+CO2MOND_DATADIR='/var/lib/co2mon/'
+
+
+def read_metric(name):
+    v = open(os.path.join(CO2MOND_DATADIR, name)).read()
+    try:
+        return int(v)
+    except ValueError:
+        return float(v)
+
+
+def read_callback(data=None):
+    vl = collectd.Values(plugin='co2mon')
+    vl.plugin = 'co2mon'
+    try:
+        vl.time = read_metric('heartbeat')
+    except:
+        pass
+    co2 = [read_metric('CntR')]
+    temp = [read_metric('Tamb')]
+    vl.dispatch(values=co2, type='gauge', type_instance='co2_ppm')
+    vl.dispatch(values=temp, type='temperature')
+
+
+def configure_callback(conf):
+    global CO2MOND_DATADIR
+    for c in conf.children:
+        if c.key == 'datadir':
+            CO2MOND_DATADIR = c.values[0]
+
+
+collectd.register_read(read_callback)
+collectd.register_config(configure_callback)


### PR DESCRIPTION
I wanted to have logs with more granularity, so here is python plugin for `collectd` to collect `co2mond` data.

`collectd` gives 10 s resolution by default, which is cool. `munin` have rather hardcoded fixed 5 min data gather interval. `munin` allows some hacky ways to disregard this limitation, but it was easier to switch to collectd.