### PR TITLE
Add trivial single-threaded prometheus exporter

### DIFF
--- a/co2mond/CMakeLists.txt
+++ b/co2mond/CMakeLists.txt
@@ -14,6 +14,7 @@ aux_source_directory(src SRC_LIST)
 add_executable(co2mond ${SRC_LIST})
 target_link_libraries(co2mond
     co2mon
+    pthread
     ${HIDAPI_LIBRARIES})
 
 install(TARGETS co2mond


### PR DESCRIPTION
I decided to implement a network service instead of writing full `.prom` file on every `write_value` to a `textfile` directory polled by `node_exporter` as that needs write-and-rename code (otherwise `node_exporter` will complain about malformed file sometimes) and it'll be less trivial if `node_exporter` and `co2mond` are running under different UIDs.