### PR TITLE
Add Content-Type header to metrics HTTP response

### DIFF
--- a/co2mond/src/main.c
+++ b/co2mond/src/main.c
@@ -282,6 +282,7 @@ prometheus_thread(void *arg)
 
         fprintf(out,
             "HTTP/1.0 200 OK\r\n"
+            "Content-Type: text/plain; charset=utf-8\r\n"
             "Server: co2mond\r\n"
             "Connection: close\r\n"
             "\r\n"


### PR DESCRIPTION
Some clients [e.g. InfluxDB](https://github.com/influxdata/influxdb/issues/20193) need a content type to parse the metrics.