### PR TITLE
switch on decoding based on release, by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,45 @@
 # Software for CO2 Monitor
 
+## Compatible Devices
+
+This software supports compact USB-powered CO2 meters that identify as:
+
+```
+  idVendor           0x04d9 Holtek Semiconductor, Inc.
+  idProduct          0xa052 USB-zyTemp
+```
+
+A of 2023, there are two revisions of these product on the
+market, that can be distinguished by its serial and release
+numbers:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                    old        new
+――――――――――――――――――――――――――――――――――
+serial_number      1.40       2.00
+release_number   0x0100     0x0200
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+(where serial_number == iSerial and release_number == bcdDevice)
+
+The co2mon software tries to auto-detect them, but its also possible to
+override the detection (cf. the `-N` and `-n` options).
+
+Note that these devices are rebranded by vendors such as TFA and
+thus are available online under different product names (e.g.
+sold by Amazon, as of 2023). Even if one user reported success
+with a certain product, the vendor might have silently switched
+to a completely different and unsupported hardware without
+changing the product name, at any time.
+
+List of user reported devices that worked in the past:
+
+- TFA AIRCO2NTROL MINI CO2 Monitor (EAN 4009816027351), via
+  Amazon.de, 2023
+
+
 ## Installation
 
 ### Arch Linux
@@ -12,7 +52,7 @@ co2mon packages can be installed from official repo:
 
 `dnf install co2mon`
 
-### From sources
+### From Source
 
     # macOS
     brew install cmake pkg-config hidapi

--- a/co2mond/src/main.c
+++ b/co2mond/src/main.c
@@ -46,7 +46,7 @@
 
 int daemonize = 0;
 int print_unknown = 0;
-int decode_data = 1;
+static int decode_data = -1; /* -1 == auto-detect old/new release devices */
 const char *devicefile = NULL;
 char *datadir;
 
@@ -524,7 +524,7 @@ int main(int argc, char *argv[])
     int c;
     int opterr = 0;
     int show_help = 0;
-    while ((c = getopt(argc, argv, ":dnhuD:P:f:l:p:")) != -1)
+    while ((c = getopt(argc, argv, ":dnNhuD:P:f:l:p:")) != -1)
     {
         switch (c)
         {
@@ -539,6 +539,9 @@ int main(int argc, char *argv[])
             break;
         case 'n':
             decode_data = 0;
+            break;
+        case 'N':
+            decode_data = 1;
             break;
         case 'D':
             reldatadir = optarg;
@@ -573,7 +576,8 @@ int main(int argc, char *argv[])
             fprintf(stderr, "  -d    run as a daemon\n");
             fprintf(stderr, "  -h    show this help message\n");
             fprintf(stderr, "  -u    print values for unknown items\n");
-            fprintf(stderr, "  -n    don't decode the data\n");
+            fprintf(stderr, "  -n    use payload as-is, as delivered by 2nd release devices (overrides auto-detection)\n");
+            fprintf(stderr, "  -N    decode payload that is scrambled by 1st release devices (overrides auto-detection)\n");
             fprintf(stderr, "  -D datadir\n");
             fprintf(stderr, "        store values from the sensor in datadir\n");
             fprintf(stderr, "  -P host:port\n");

--- a/libco2mon/src/co2mon.c
+++ b/libco2mon/src/co2mon.c
@@ -22,7 +22,7 @@
 
 #include "co2mon.h"
 
-static int decode_data = 1;
+static int decode_data = -1;
 
 int
 co2mon_init(int decode)
@@ -53,6 +53,15 @@ co2mon_open_device()
     if (!dev)
     {
         fprintf(stderr, "hid_open: error\n");
+    }
+    if (decode_data == -1)
+    {
+        struct hid_device_info *hdi = hid_get_device_info(dev);
+        if (hdi && hdi->release_number >  0x0100) {
+            decode_data = 0;
+        } else {
+            decode_data = 1;
+        }
     }
     return dev;
 }


### PR DESCRIPTION
That means, by default, co2mon uses the USB device's release number to auto-detect whether deoding/descrambling of the payload is necessary.

fixes #41