### PR TITLE
Skip decode_data guessing when no device available

### DIFF
--- a/libco2mon/src/co2mon.c
+++ b/libco2mon/src/co2mon.c
@@ -54,7 +54,7 @@ co2mon_open_device()
     {
         fprintf(stderr, "hid_open: error\n");
     }
-    if (decode_data == -1)
+    else if (decode_data == -1)
     {
         struct hid_device_info *hdi = hid_get_device_info(dev);
         if (hdi && hdi->release_number >  0x0100) {


### PR DESCRIPTION
If hid_open fails, we don't have any information about the device and shouldn't use hid_get_device_info.